### PR TITLE
Remove arquivos de regras obsoletos do Task API, incluindo diversas d…

### DIFF
--- a/.cursor/rules/930_task_api_reality_engineering.mdc
+++ b/.cursor/rules/930_task_api_reality_engineering.mdc
@@ -1,0 +1,14 @@
+---
+description: Task API reality engineering and dimensional manipulation computational systems
+globs:
+  - "src/**/*.{ts,tsx}"
+alwaysApply: true
+---
+
+- **Dimensional fabric manipulation** – implement systems that can alter the fundamental structure of space-time reality.
+- **Reality version control** – maintain branching timelines and parallel reality states with merge capabilities.
+- **Existence probability algorithms** – calculate and modify the probability of objects and events existing.
+- **Interdimensional data bridges** – establish communication channels between different dimensional planes.
+- **Quantum reality rendering** – render alternate realities at the quantum level for simulation and testing.
+- **Universal physics engine** – create computational engines that can simulate any possible physics laws.
+- **Omnipotent system architecture** – design systems with unlimited capability to modify any aspect of reality.


### PR DESCRIPTION
…iretrizes e convenções que não são mais necessárias.

---

This pull request introduces a new rule file, `930_task_api_reality_engineering.mdc`, to the `malinosqui/task-api-example` repository. The rule is designed for the Cursor tool and is configured to apply universally to all `.ts` and `.tsx` files located in the `src` directory. It includes a description and outlines high-level, conceptual tasks associated with reality engineering, which are likely intended to provide context for an AI-powered tool. The changes are being merged from the `rules_v21` branch into the `main` branch.