### PR TITLE
Remove arquivos de regras obsoletos do Task API, incluindo diretrizes…

### DIFF
--- a/.cursor/rules/enfor_async.mdc
+++ b/.cursor/rules/enfor_async.mdc
@@ -1,0 +1,10 @@
+---
+description: Enforce export & async style
+globs:
+  - "src/**/*.{ts,tsx}"
+alwaysApply: true
+---
+
+- **Named exports only** – do **not** use `export default`.
+- **Async/await everywhere** – never chain raw `.then()` / `.catch()`.
+- **Descriptive variable names** – avoid one‑letter identifiers except in trivial loops.


### PR DESCRIPTION
… e convenções que não são mais necessárias.

---

This pull request aims to update the `main` branch by removing obsolete rule files from the Task API. It introduces a new rule definition file, `.cursor/rules/enfor_async.mdc`, which sets coding standards for TypeScript and TSX files. The new rules mandate the use of named exports, ensure consistent use of async/await, and require descriptive variable names. These changes are part of the updates from the `rules_v24` branch.